### PR TITLE
fix: KeyError

### DIFF
--- a/stable_diffusion.ipynb
+++ b/stable_diffusion.ipynb
@@ -89,7 +89,7 @@
         "\n",
         "prompts = [ prompt ] * num_images\n",
         "with autocast(\"cuda\"):\n",
-        "    images = pipe(prompts, guidance_scale=7.5, num_inference_steps=50)[\"sample\"]  \n",
+        "    images = pipe(prompts, guidance_scale=7.5, num_inference_steps=50).images  \n",
         "    \n",
         "media.show_images(images)\n",
         "images[0].save(\"output.jpg\")"


### PR DESCRIPTION
Accroding to this [issue](https://github.com/CompVis/stable-diffusion/issues/402), `["sample"]` can no longer work.
Should be changed to `images`