### PR TITLE
Switch model weights to runwayml/stable-diffusion-v1-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Moreover, as for the DALL·E model, you are asked to abide to the following stat
 
 [huggingface-blogpost]: <https://huggingface.co/blog/stable_diffusion>
 [huggingface-models]: <https://huggingface.co/CompVis/stable-diffusion>
-[huggingface-latest-weights]: <https://huggingface.co/CompVis/stable-diffusion-v1-4>
+[huggingface-latest-weights]: <https://huggingface.co/runwayml/stable-diffusion-v1-5>
 [huggingface-demo]: <https://huggingface.co/spaces/stabilityai/stable-diffusion>
 [dreamstudio-demo]: <http://beta.dreamstudio.ai>
 [edm-implementation]: <https://github.com/NVlabs/edm>

--- a/stable_diffusion.ipynb
+++ b/stable_diffusion.ipynb
@@ -64,7 +64,7 @@
         "from torch import autocast\n",
         "from diffusers import StableDiffusionPipeline\n",
         "\n",
-        "model_id = \"CompVis/stable-diffusion-v1-4\"\n",
+        "model_id = \"runwayml/stable-diffusion-v1-5\"\n",
         "device = \"cuda\"\n",
         "remove_safety = False\n",
         "\n",


### PR DESCRIPTION
This changes the model ID to `runwayml/stable-diffusion-v1-5`: [demo][runwayml-demo] and [weights][runwayml-weights].

<!-- Definitions -->

[runwayml-demo]: <https://huggingface.co/spaces/runwayml/stable-diffusion-v1-5>
[runwayml-weights]: <https://huggingface.co/runwayml/stable-diffusion-v1-5>