### PR TITLE
Add seed support

### DIFF
--- a/stable_diffusion.ipynb
+++ b/stable_diffusion.ipynb
@@ -5,8 +5,7 @@
     "colab": {
       "name": "stable-diffusion.ipynb",
       "private_outputs": true,
-      "provenance": [],
-      "collapsed_sections": []
+      "provenance": []
     },
     "kernelspec": {
       "name": "python3",
@@ -79,6 +78,7 @@
         "import mediapy as media\n",
         "import torch\n",
         "from diffusers import StableDiffusionPipeline\n",
+        "import random\n",
         "\n",
         "device = \"cuda\"\n",
         "\n",
@@ -121,6 +121,7 @@
         "prompt = \"a photo of Pikachu fine dining with a view to the Eiffel Tower\"\n",
         "remove_safety = False\n",
         "num_images = 4\n",
+        "seed = random.randint(0, 2147483647)\n",
         "\n",
         "if remove_safety:\n",
         "  negative_prompt = None\n",
@@ -136,9 +137,11 @@
         "    guidance_scale = 9,\n",
         "    num_images_per_prompt = num_images,\n",
         "    negative_prompt = negative_prompt,\n",
+        "    generator = torch.Generator(\"cuda\").manual_seed(seed)\n",
         "    ).images\n",
         "    \n",
         "media.show_images(images)\n",
+        "display(f\"Seed: {seed}\")\n",
         "images[0].save(\"output.jpg\")"
       ],
       "metadata": {


### PR DESCRIPTION
This PR aims to set and display a random seed value after the images in the output. This could be useful for users. Moreover, this also makes it possible to set the seed manually.

Here, the seed is considered a signed 32-bit integer.